### PR TITLE
Fix typo in sample code

### DIFF
--- a/Samples/Media SDK/VideoExportSample/Program.cs
+++ b/Samples/Media SDK/VideoExportSample/Program.cs
@@ -75,7 +75,7 @@ static async Task RunSample()
     }
     catch (Exception ex)
     {
-        Console.WriteLine($"An error occured while exporting video: {ex.Message}");
+        Console.WriteLine($"An error occurred while exporting video: {ex.Message}");
     }
 }
 

--- a/Samples/Plugin SDK/CustomReportSample/Client/CustomReportPageDescriptor.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Client/CustomReportPageDescriptor.cs
@@ -16,7 +16,7 @@ public class CustomReportPageDescriptor : PageDescriptor
 
     public override Guid CategoryId => new(TaskCategories.Investigation);
 
-    public override string Description => "View custom events that occured on selected entities";
+    public override string Description => "View custom events that occurred on selected entities";
 
     public override ImageSource Icon { get; } = new BitmapImage(new Uri("pack://application:,,,/CustomReportSample;component/Resources/Images/SmallLogo.png"));
 


### PR DESCRIPTION
## Summary
- fix misspelling `occured` → `occurred` in plugin and media samples

## Testing
- `grep -Rin "occured" .`


------
https://chatgpt.com/codex/tasks/task_e_684c21459d508320a0e3ab1f68f27041