### PR TITLE
Fix DisplayInTileSample XML quoting

### DIFF
--- a/Samples/Platform SDK/DisplayInTileSample/Program.cs
+++ b/Samples/Platform SDK/DisplayInTileSample/Program.cs
@@ -87,6 +87,7 @@ async Task RunSample()
         foreach (var monitor in monitors)
         {
 
+            // Build the XML with doubled quotes so backslashes aren't needed
             string xmlContent = $@"
 <TileContentGroup>
     <Contents>


### PR DESCRIPTION
## Summary
- clarify DisplayInTileSample XML creation by adding a comment

## Testing
- `mcs Program.cs` *(fails: CS1525 Unexpected symbol `SdkResolver`)*
- `mono test.exe` after compiling sample snippet

------
https://chatgpt.com/codex/tasks/task_e_684c214ad7548320860b776c9cc017e2