### PR TITLE
Fix typos in docs and sample code

### DIFF
--- a/Samples/Media SDK/VideoExportSample/Program.cs
+++ b/Samples/Media SDK/VideoExportSample/Program.cs
@@ -75,7 +75,7 @@ static async Task RunSample()
     }
     catch (Exception ex)
     {
-        Console.WriteLine($"An error occured while exporting video: {ex.Message}");
+        Console.WriteLine($"An error occurred while exporting video: {ex.Message}");
     }
 }
 

--- a/Samples/Plugin SDK/BasicPluginTemplate/ReadMe.md
+++ b/Samples/Plugin SDK/BasicPluginTemplate/ReadMe.md
@@ -65,11 +65,11 @@ By using the Plugin SDK, developers can create powerful, deeply integrated solut
 
 ## Getting Started
 
-1.  Install the latest Genetec Security Center SDK. This will creates the necessary environment variables automatically.
+1.  Install the latest Genetec Security Center SDK. This will create the necessary environment variables automatically.
    -   `GSC_SDK`: Points to the location of the Genetec SDK for .NET Framework 4.8.1
    -   `GSC_SDK_CORE`: Points to the location of the Genetec SDK for .NET 8
 3.  Clone this repository to your local machine.
-4.  Open the solution in Visual Studio **as an Adminstrator**.
+4.  Open the solution in Visual Studio **as an Administrator**.
 5.  Build the BasicPluginTemplate project.
 
 ## Creating a Plugin

--- a/Samples/Plugin SDK/CustomReportSample/Client/CustomReportPageDescriptor.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Client/CustomReportPageDescriptor.cs
@@ -16,7 +16,7 @@ public class CustomReportPageDescriptor : PageDescriptor
 
     public override Guid CategoryId => new(TaskCategories.Investigation);
 
-    public override string Description => "View custom events that occured on selected entities";
+    public override string Description => "View custom events that occurred on selected entities";
 
     public override ImageSource Icon { get; } = new BitmapImage(new Uri("pack://application:,,,/CustomReportSample;component/Resources/Images/SmallLogo.png"));
 

--- a/Samples/Plugin SDK/CustomReportSample/ReadMe.md
+++ b/Samples/Plugin SDK/CustomReportSample/ReadMe.md
@@ -40,7 +40,7 @@ By using the Plugin SDK, developers can create powerful, deeply integrated solut
 - Genetec Security Center SDK
 - Visual Studio 2022
 ## Getting Started
-1.  Install the latest Genetec Security Center SDK. This will creates the necessary environment variables automatically.
+1.  Install the latest Genetec Security Center SDK. This will create the necessary environment variables automatically.
    -   `GSC_SDK`: Points to the location of the Genetec SDK for .NET Framework 4.8.1
    -   `GSC_SDK_CORE`: Points to the location of the Genetec SDK for .NET 8
 3.  Clone this repository to your local machine.

--- a/Samples/Plugin SDK/PluginDatabaseSample/ReadMe.md
+++ b/Samples/Plugin SDK/PluginDatabaseSample/ReadMe.md
@@ -40,7 +40,7 @@ By using the Plugin SDK, developers can create powerful, deeply integrated solut
 - Genetec Security Center SDK
 - Visual Studio 2022
 ## Getting Started
-1.  Install the latest Genetec Security Center SDK. This will creates the necessary environment variables automatically.
+1.  Install the latest Genetec Security Center SDK. This will create the necessary environment variables automatically.
    -   `GSC_SDK`: Points to the location of the Genetec SDK for .NET Framework 4.8.1
    -   `GSC_SDK_CORE`: Points to the location of the Genetec SDK for .NET 8
 3.  Clone this repository to your local machine.


### PR DESCRIPTION
## Summary
- fix small typos in plugin READMEs
- correct `occurred` in sample code and docs

## Testing
- `codespell -q 2`

------
https://chatgpt.com/codex/tasks/task_e_685193bf14588320a7f5ea1c199816f5